### PR TITLE
Remove unnecessary symbols from Datastore.java

### DIFF
--- a/src/main/java/com/google/codeu/data/Datastore.java
+++ b/src/main/java/com/google/codeu/data/Datastore.java
@@ -151,8 +151,5 @@ public class Datastore {
     
       return messages;
      }
-<<<<<<< HEAD
 
-=======
->>>>>>> f4aeb11864ced90492d877b489cf213f54763a0e
 }


### PR DESCRIPTION
This PR removes the merge conflict symbols in the Datastore.java file that I accidentally left in there! 